### PR TITLE
I checked Grasses v67 and have a question.

### DIFF
--- a/src/CohortBiomass.cs
+++ b/src/CohortBiomass.cs
@@ -237,6 +237,7 @@ namespace Landis.Extension.Succession.NECN
                 CalibrateLog.limitH20 = limitH20;
                 CalibrateLog.limitT = limitT;
                 CalibrateLog.limitN = limitN;
+                CalibrateLog.limitLAIcompetition = competition_limit; // Chihiro, 2021.03.26: added
                 CalibrateLog.maxNPP = maxNPP;
                 CalibrateLog.maxB = maxBiomass;
                 CalibrateLog.siteB = siteBiomass;
@@ -631,6 +632,7 @@ namespace Landis.Extension.Succession.NECN
                     CalibrateLog.actual_LAI_tree = 0;
                 CalibrateLog.base_lai = base_lai;
                 CalibrateLog.seasonal_adjustment = seasonal_adjustment;
+                CalibrateLog.siteLAI = SiteVars.MonthlyLAI[site][Main.Month]; // Chihiro, 2021.03.26: added
                 //Outputs.CalibrateLog.Write("{0:0.00},{1:0.00},{2:0.00},", lai, base_lai, seasonal_adjustment);
             }
 

--- a/src/CohortBiomass.cs
+++ b/src/CohortBiomass.cs
@@ -621,6 +621,10 @@ namespace Landis.Extension.Succession.NECN
             // Tracking Tree species LAI above grasses
             if (!SpeciesData.Grass[cohort.Species])
                 SiteVars.MonthlyLAI_Trees[site][Main.Month] += lai;
+            else
+                SiteVars.MonthlyLAI_Grasses[site][Main.Month] += lai; // Chihiro, 2021.03.30: tentative
+                
+
 
 
             if (PlugIn.ModelCore.CurrentTime > 0 && OtherData.CalibrateMode)
@@ -674,7 +678,8 @@ namespace Landis.Extension.Succession.NECN
             }
             else
             {
-                monthly_cumulative_LAI = SiteVars.MonthlyLAI[site][Main.Month];
+                // monthly_cumulative_LAI = SiteVars.MonthlyLAI[site][Main.Month];
+                monthly_cumulative_LAI = SiteVars.MonthlyLAI_Trees[site][Main.Month] + SiteVars.MonthlyLAI_GrassesLastMonth[site]; // Chihiro, 2021.03.30: tentative. trees + grass layer
             }
 
             double competition_limit = Math.Max(0.0, Math.Exp(k * monthly_cumulative_LAI));

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -68,6 +68,7 @@ namespace Landis.Extension.Succession.NECN
                     SiteVars.MonthlyStreamN[site][Month] = 0.0;
                     SiteVars.MonthlyLAI[site][Month] = 0.0;
                     SiteVars.MonthlyLAI_Trees[site][Month] = 0.0;
+                    SiteVars.MonthlyLAI_Grasses[site][Month] = 0.0; // Chihiro, 2020.03.30: tentative
                     SiteVars.MonthlySoilWaterContent[site][Month] = 0.0;
                     SiteVars.SourceSink[site].Carbon = 0.0;
                     SiteVars.TotalWoodBiomass[site] = Main.ComputeWoodBiomass((ActiveSite) site);
@@ -107,6 +108,11 @@ namespace Landis.Extension.Succession.NECN
                         siteCohorts.Grow(site, (y == years && isSuccessionTimeStep), true);
                     else
                         siteCohorts.Grow(site, (y == years && isSuccessionTimeStep), false);
+
+                    // Track the grasses species LAI on the site
+                    // Chihiro 2021.03.30: tentative
+                    SiteVars.MonthlyLAI_GrassesLastMonth[site] = SiteVars.MonthlyLAI_Grasses[site][Month];
+
 
                     WoodLayer.Decompose(site);
                     LitterLayer.Decompose(site);

--- a/src/SiteVars.cs
+++ b/src/SiteVars.cs
@@ -105,6 +105,8 @@ namespace Landis.Extension.Succession.NECN
         public static ISiteVar<double[]> MonthlySoilResp;
         public static ISiteVar<double[]> MonthlyLAI;
         public static ISiteVar<double[]> MonthlyLAI_Trees;
+        public static ISiteVar<double[]> MonthlyLAI_Grasses; // Chihiro, 2021.03.30: tentative
+        public static ISiteVar<double> MonthlyLAI_GrassesLastMonth; // Chihiro, 2021.03.30: tentative
         public static ISiteVar<double[]> MonthlyHeteroResp;
         public static ISiteVar<double[]> MonthlySoilWaterContent;
 
@@ -154,6 +156,8 @@ namespace Landis.Extension.Succession.NECN
             // Other variables
             MonthlyLAI = PlugIn.ModelCore.Landscape.NewSiteVar<double[]>();
             MonthlyLAI_Trees = PlugIn.ModelCore.Landscape.NewSiteVar<double[]>();
+            MonthlyLAI_Grasses = PlugIn.ModelCore.Landscape.NewSiteVar<double[]>();  // Chihiro, 2021.03.30: tentative
+            MonthlyLAI_GrassesLastMonth = PlugIn.ModelCore.Landscape.NewSiteVar<double>();  // Chihiro, 2021.03.30: tentative
             mineralN = PlugIn.ModelCore.Landscape.NewSiteVar<double>();
             resorbedN           = PlugIn.ModelCore.Landscape.NewSiteVar<double>();
             waterMovement       = PlugIn.ModelCore.Landscape.NewSiteVar<double>();
@@ -244,6 +248,7 @@ namespace Landis.Extension.Succession.NECN
                 MonthlySoilResp[site] = new double[12];
                 MonthlyLAI[site] = new double[12];
                 MonthlyLAI_Trees[site] = new double[12];
+                MonthlyLAI_Grasses[site] = new double[12];
                 MonthlySoilWaterContent[site]       = new double[12];
 
                 CohortResorbedNallocation[site] = new Dictionary<int, Dictionary<int, double>>();

--- a/src/metadata/CalibrateLog.cs
+++ b/src/metadata/CalibrateLog.cs
@@ -14,9 +14,9 @@ namespace Landis.Extension.Succession.NECN
         public static string speciesName;
         public static double mortalityAGEwood, mortalityAGEleaf;
         public static double availableWater;
-        public static double actual_LAI, actual_LAI_tree, base_lai, seasonal_adjustment;
+        public static double actual_LAI, actual_LAI_tree, base_lai, seasonal_adjustment, siteLAI;
         public static double mineralNalloc, resorbedNalloc;
-        public static double limitLAI, limitH20, limitT, limitN;
+        public static double limitLAI, limitH20, limitT, limitN, limitLAIcompetition;
         public static double maxNPP, maxB, siteB, cohortB, soilTemp;
         public static double actualWoodNPP, actualLeafNPP;
         public static double deltaWood, deltaLeaf;
@@ -41,7 +41,9 @@ namespace Landis.Extension.Succession.NECN
             clog.MortalityTHINwoodBiomass = mortalityBIOwood;
             clog.MortalityTHINleafBiomass = mortalityBIOleaf;
             clog.AvailableWater = availableWater;
-            clog.TotalLAI = actual_LAI;
+            clog.ActualLAI = actual_LAI; // Chihiro, 2021.03.26: renamed
+            clog.TreeLAI = actual_LAI_tree;
+            clog.SiteLAI = siteLAI; // Chihiro, 2021.03.26: added
             clog.BaseLAI = base_lai;
             clog.SeaonalAdjustLAI = seasonal_adjustment;
             clog.MineralNalloc = mineralNalloc;
@@ -52,6 +54,7 @@ namespace Landis.Extension.Succession.NECN
             clog.GrowthLimitN = limitN;
             clog.GrowthLimitSoilWater = limitH20;
             clog.GrowthLimitT = limitT;
+            clog.GrowthLimitLAIcompetition = limitLAIcompetition; // Chihiro, 2021.03.26: added
             clog.MaximumANPP = maxNPP;
             clog.CohortMaximumBiomass = maxB;
             clog.TotalSiteBiomass = siteB;
@@ -113,11 +116,17 @@ namespace Landis.Extension.Succession.NECN
         [DataFieldAttribute(Unit = "Fraction", Desc = "Seaonal LAI Adjust", Format = "0.00")]
         public double SeaonalAdjustLAI { set; get; }
         // ********************************************************************
-        [DataFieldAttribute(Unit = "m2_m-2", Desc = "Total Leaf Area Index", Format = "0.0")]
-        public double TotalLAI { set; get; }
+        // Chihiro, 2021.03.26: modified from LAI
+        [DataFieldAttribute(Unit = "m2_m-2", Desc = "Actual LAI adjusted by seasonality", Format = "0.0")]
+        public double ActualLAI { set; get; }
         // ********************************************************************
+        // Chihiro, 2021.03.26: added
+        [DataFieldAttribute(Unit = "m2_m-2", Desc = "Site Total LAI above this cohort", Format = "0.0")]
+        public double SiteLAI { set; get; }
+        // ********************************************************************
+        // Chihiro, 2021.03.26: added
         [DataFieldAttribute(Unit = "m2_m-2", Desc = "Tree Leaf Area Index", Format = "0.0")]
-        public double TreLAI { set; get; }
+        public double TreeLAI { set; get; }
         // ********************************************************************
         [DataFieldAttribute(Unit = "Fraction", Desc = "Growth Limit LAI", Format = "0.00")]
         public double GrowthLimitLAI { set; get; }
@@ -130,6 +139,10 @@ namespace Landis.Extension.Succession.NECN
         // ********************************************************************
         [DataFieldAttribute(Unit = "Fraction", Desc = "Growth Limit Nitrogen", Format = "0.00")]
         public double GrowthLimitN { set; get; }
+        // ********************************************************************
+        // Chihiro, 2021.03.26: added
+        [DataFieldAttribute(Unit = "Fraction", Desc = "Growth Limit LAI competition", Format = "0.00")]
+        public double GrowthLimitLAIcompetition { set; get; }
         // ********************************************************************
         [DataFieldAttribute(Unit = "g_B_m2_month1", Desc = "Maximum ANPP")]
         public double MaximumANPP { set; get; }


### PR DESCRIPTION
Dear @rmscheller ,

# Summary
We reviewed your codes on Grasses_v67 and modified some parts (slide pp. 2, commit ID == 5a09586). This version successfully suppressed young tree saplings as we expected (slide pp. 3 attached in the email).

However, grasses could not suppress old tree saplings in commit 5a09586 (slide pp.4). This is because NECN assumes older cohorts are always taller than young cohorts (slide pp.5). For this reason, NECN ignores the LAI of young grass species in the calculation of competition_limit for old tree saplings with small AGB.

Then, we tested a new functionality to avoid ignoring young grass species in the calculation of competition_limit (slide pp. 6-7) (commit ID == 121874d). But I'm wondering that this modification is violating an important concept of NECN or not.

# Requests & Questions:
1. Please re-review the pull-request (commit ID == 
5a09586). There is some modification on the calibrate log file.
2. Is the commit ID == 121874d acceptable for the current NECN development? Or is it better to discard the commit ID == 121874d and write the above limitation in the Users Guide?

Thank you,
Chihiro
