### PR TITLE
Add SOM1Csurface to soil output maps

### DIFF
--- a/src/Outputs.cs
+++ b/src/Outputs.cs
@@ -886,6 +886,24 @@ namespace Landis.Extension.Succession.NECN
                     outputRaster.WriteBufferPixel();
                 }
             }
+            string input_map_10 = MapNames.ReplaceTemplateVars(@"NECN-Initial-Conditions\SOM1Csurface-{timestep}.img", PlugIn.ModelCore.CurrentTime);
+            using (IOutputRaster<DoublePixel> outputRaster = PlugIn.ModelCore.CreateRaster<DoublePixel>(input_map_1, PlugIn.ModelCore.Landscape.Dimensions))
+            {
+                DoublePixel pixel = outputRaster.BufferPixel;
+                foreach (Site site in PlugIn.ModelCore.Landscape.AllSites)
+                {
+                    if (site.IsActive)
+                    {
+                        pixel.MapCode.Value = (double)((SiteVars.SOM1surface[site].Carbon));
+                    }
+                    else
+                    {
+                        //  Inactive site
+                        pixel.MapCode.Value = 0;
+                    }
+                    outputRaster.WriteBufferPixel();
+                }
+            }
         }
         //---------------------------------------------------------------------
         private static double GetTotalNitrogen(Site site)


### PR DESCRIPTION
SOM1Csurface was missing from the set of soil outputs for re-initializing NECN