### PR TITLE
Update PlugIn.cs

### DIFF
--- a/src/PlugIn.cs
+++ b/src/PlugIn.cs
@@ -558,7 +558,7 @@ namespace Landis.Extension.Succession.NECN
 
         public void AddNewCohort(ISpecies species, ActiveSite site, string reproductionType, double propBiomass = 1.0)
         {
-            float[] initialBiomass = CohortBiomass.InitialBiomass(species, SiteVars.Cohorts[site], site);
+            float[] initialBiomass = CohortBiomass.InitialBiomass(species, site);
 
             ExpandoObject woodLeafBiomasses = new ExpandoObject();
             dynamic tempObject = woodLeafBiomasses;


### PR DESCRIPTION
The most recent commit (4bc4d5a) removed the ISiteCohorts argument from the `InitialBiomass` method in `CohortBiomass.cs`, but [line 561](https://github.com/LANDIS-II-Foundation/Extension-NECN-Succession/blob/4bc4d5a7cb5a1a88582b04b7e9ed509fffbd7596/src/PlugIn.cs#L561) of PlugIn.cs is still trying to feed it three arguments. I was able to get it to compile by removing `SiteVars.Cohorts[site]` from the arguments.